### PR TITLE
Add Presto configuration and MCP support models

### DIFF
--- a/src/main/java/com/santec/polenta/PolentaMcpServerApplication.java
+++ b/src/main/java/com/santec/polenta/PolentaMcpServerApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
+import com.santec.polenta.config.PrestoConfig;
+
 @SpringBootApplication
-@EnableConfigurationProperties
+@EnableConfigurationProperties(PrestoConfig.class)
 public class PolentaMcpServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/santec/polenta/config/PrestoConfig.java
+++ b/src/main/java/com/santec/polenta/config/PrestoConfig.java
@@ -1,0 +1,83 @@
+package com.santec.polenta.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration properties for connecting to PrestoDB.
+ */
+@Configuration
+@ConfigurationProperties(prefix = "presto")
+public class PrestoConfig {
+
+    /** JDBC URL including catalog and schema */
+    private String url;
+    /** Presto username */
+    private String user;
+    /** Presto password (optional) */
+    private String password;
+    /** Catalog used for queries */
+    private String catalog;
+    /** Default schema used for queries */
+    private String schema;
+    /** Connection timeout in milliseconds */
+    private long connectionTimeout;
+    /** Query timeout in milliseconds */
+    private long queryTimeout;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getCatalog() {
+        return catalog;
+    }
+
+    public void setCatalog(String catalog) {
+        this.catalog = catalog;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    public long getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(long connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public long getQueryTimeout() {
+        return queryTimeout;
+    }
+
+    public void setQueryTimeout(long queryTimeout) {
+        this.queryTimeout = queryTimeout;
+    }
+}

--- a/src/main/java/com/santec/polenta/model/mcp/McpError.java
+++ b/src/main/java/com/santec/polenta/model/mcp/McpError.java
@@ -1,0 +1,66 @@
+package com.santec.polenta.model.mcp;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Standard MCP error object following JSON-RPC error structure.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class McpError {
+
+    @JsonProperty("code")
+    private int code;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("data")
+    private Object data;
+
+    public McpError() {
+    }
+
+    public McpError(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public McpError(int code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static McpError internalError(String message) {
+        return new McpError(-32603, message);
+    }
+
+    public static McpError invalidRequest(String message) {
+        return new McpError(-32600, message);
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/com/santec/polenta/model/mcp/McpTool.java
+++ b/src/main/java/com/santec/polenta/model/mcp/McpTool.java
@@ -1,0 +1,55 @@
+package com.santec.polenta.model.mcp;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * Definition of a tool exposed by the MCP server.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class McpTool {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("inputSchema")
+    private Map<String, Object> inputSchema;
+
+    public McpTool() {
+    }
+
+    public McpTool(String name, String description, Map<String, Object> inputSchema) {
+        this.name = name;
+        this.description = description;
+        this.inputSchema = inputSchema;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Map<String, Object> getInputSchema() {
+        return inputSchema;
+    }
+
+    public void setInputSchema(Map<String, Object> inputSchema) {
+        this.inputSchema = inputSchema;
+    }
+}

--- a/src/main/java/com/santec/polenta/service/PrestoService.java
+++ b/src/main/java/com/santec/polenta/service/PrestoService.java
@@ -120,7 +120,15 @@ public class PrestoService {
         if (prestoConfig.getPassword() != null && !prestoConfig.getPassword().isEmpty()) {
             properties.setProperty("password", prestoConfig.getPassword());
         }
-        
+
+        if (prestoConfig.getConnectionTimeout() > 0) {
+            properties.setProperty("connectionTimeout", String.valueOf(prestoConfig.getConnectionTimeout()));
+        }
+
+        if (prestoConfig.getQueryTimeout() > 0) {
+            properties.setProperty("socketTimeout", String.valueOf(prestoConfig.getQueryTimeout()));
+        }
+
         return DriverManager.getConnection(prestoConfig.getUrl(), properties);
     }
     


### PR DESCRIPTION
## Summary
- implement PrestoConfig to expose connection properties for PrestoDB
- add McpError and McpTool models for protocol compliance
- register PrestoConfig and use timeout settings in PrestoService

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM for com.santec:polenta-mcp-server:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68953d9f9cbc832ea9f4419b1e8e2169