### PR TITLE
Add Swagger support for MCP API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,13 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- OpenAPI/Swagger documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+
         <!-- PrestoDB JDBC Driver -->
         <dependency>
             <groupId>io.prestodb</groupId>

--- a/src/main/java/com/santec/polenta/config/OpenApiConfig.java
+++ b/src/main/java/com/santec/polenta/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.santec.polenta.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Basic OpenAPI configuration to enable Swagger UI documentation.
+ */
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(
+        title = "Polenta MCP API",
+        version = "1.0",
+        description = "API for interacting with the Polenta MCP server"
+    )
+)
+public class OpenApiConfig {
+}
+

--- a/src/main/java/com/santec/polenta/controller/McpController.java
+++ b/src/main/java/com/santec/polenta/controller/McpController.java
@@ -3,6 +3,8 @@ package com.santec.polenta.controller;
 import com.santec.polenta.model.mcp.*;
 import com.santec.polenta.service.QueryIntelligenceService;
 import com.santec.polenta.service.PrestoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +20,7 @@ import java.util.*;
 @RestController
 @RequestMapping("/mcp")
 @CrossOrigin(origins = "*")
+@Tag(name = "MCP", description = "Endpoints for interacting with the MCP server")
 public class McpController {
     
     private static final Logger logger = LoggerFactory.getLogger(McpController.class);
@@ -41,6 +44,7 @@ public class McpController {
      * MCP Initialize endpoint - establishes connection with client
      */
     @PostMapping("/initialize")
+    @Operation(summary = "Initialize connection with the MCP server")
     public ResponseEntity<McpResponse<Map<String, Object>>> initialize(@RequestBody McpRequest request) {
         logger.info("MCP Initialize request received");
         
@@ -56,6 +60,7 @@ public class McpController {
      * MCP Tools List endpoint - returns available tools
      */
     @PostMapping("/tools/list")
+    @Operation(summary = "List available MCP tools")
     public ResponseEntity<McpResponse<Map<String, Object>>> listTools(@RequestBody McpRequest request) {
         logger.info("MCP Tools list request received");
         
@@ -90,6 +95,7 @@ public class McpController {
      * MCP Tools Call endpoint - executes tool calls
      */
     @PostMapping("/tools/call")
+    @Operation(summary = "Execute an MCP tool")
     public ResponseEntity<McpResponse<Map<String, Object>>> callTool(@RequestBody McpRequest request) {
         logger.info("MCP Tool call request received");
         
@@ -113,6 +119,7 @@ public class McpController {
      * Health check endpoint
      */
     @GetMapping("/health")
+    @Operation(summary = "Service health status")
     public ResponseEntity<Map<String, Object>> health() {
         Map<String, Object> health = new HashMap<>();
         health.put("status", "UP");


### PR DESCRIPTION
## Summary
- integrate springdoc-openapi to document the service
- expose controller metadata for Swagger testing

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896063cec00832e906eeb6edce0e54a