### PR TITLE
feat: add accessible table discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,19 @@ Ejecuta consultas en lenguaje natural o SQL directo.
 ### 2. `list_tables`
 Lista todas las tablas disponibles organizadas por esquema.
 
-### 3. `describe_table`
+### 3. `accessible_tables`
+Lista únicamente las tablas a las que el usuario tiene permiso de consulta.
+
+### 4. `describe_table`
 Obtiene información detallada sobre la estructura de una tabla específica.
 
-### 4. `sample_data`
+### 5. `sample_data`
 Obtiene datos de muestra de una tabla (limitado a 10 filas).
 
-### 5. `search_tables`
+### 6. `search_tables`
 Busca tablas que contengan palabras clave específicas.
 
-### 6. `get_suggestions`
+### 7. `get_suggestions`
 Proporciona sugerencias útiles de consultas para usuarios.
 
 ## Ejemplos de Consultas en Lenguaje Natural
@@ -107,6 +110,7 @@ Proporciona sugerencias útiles de consultas para usuarios.
 "Busca tablas que contengan 'ventas'"
 "¿Qué columnas tiene la tabla pedidos?"
 "Muestra los primeros 10 registros de usuarios"
+"¿Qué tablas puedo consultar?"
 ```
 
 ## Integración con Clientes MCP

--- a/src/main/java/com/santec/polenta/controller/McpController.java
+++ b/src/main/java/com/santec/polenta/controller/McpController.java
@@ -65,16 +65,19 @@ public class McpController {
         logger.info("MCP Tools list request received");
         
         List<McpTool> tools = Arrays.asList(
-            createTool("query_data", 
+            createTool("query_data",
                 "Execute natural language or SQL queries against the data lake",
                 createQuerySchema()),
-            createTool("list_tables", 
+            createTool("list_tables",
                 "List all available tables in the data lake",
                 createListTablesSchema()),
-            createTool("describe_table", 
+            createTool("accessible_tables",
+                "List tables the user has permission to query",
+                createAccessibleTablesSchema()),
+            createTool("describe_table",
                 "Get detailed information about a specific table structure",
                 createDescribeTableSchema()),
-            createTool("sample_data", 
+            createTool("sample_data",
                 "Get sample data from a specific table",
                 createSampleDataSchema()),
             createTool("search_tables", 
@@ -142,7 +145,10 @@ public class McpController {
                 
             case "list_tables":
                 return queryIntelligenceService.processNaturalQuery("show all tables");
-                
+
+            case "accessible_tables":
+                return queryIntelligenceService.processNaturalQuery("show accessible tables");
+
             case "describe_table":
                 String tableName = (String) arguments.get("table_name");
                 return queryIntelligenceService.processNaturalQuery("describe table " + tableName);
@@ -212,6 +218,13 @@ public class McpController {
     }
     
     private Map<String, Object> createListTablesSchema() {
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        schema.put("properties", Map.of());
+        return schema;
+    }
+
+    private Map<String, Object> createAccessibleTablesSchema() {
         Map<String, Object> schema = new HashMap<>();
         schema.put("type", "object");
         schema.put("properties", Map.of());

--- a/src/main/java/com/santec/polenta/service/QueryIntelligenceService.java
+++ b/src/main/java/com/santec/polenta/service/QueryIntelligenceService.java
@@ -26,6 +26,8 @@ public class QueryIntelligenceService {
         Pattern.compile("(?i).*show.*tables.*"), "SHOW_TABLES",
         Pattern.compile("(?i).*list.*tables.*"), "SHOW_TABLES",
         Pattern.compile("(?i).*what.*tables.*"), "SHOW_TABLES",
+        Pattern.compile("(?i).*accessible.*tables.*"), "ACCESSIBLE_TABLES",
+        Pattern.compile("(?i).*tables.*can.*access.*"), "ACCESSIBLE_TABLES",
         Pattern.compile("(?i).*describe.*table.*"), "DESCRIBE_TABLE",
         Pattern.compile("(?i).*columns.*in.*"), "DESCRIBE_TABLE",
         Pattern.compile("(?i).*structure.*of.*"), "DESCRIBE_TABLE",
@@ -46,6 +48,8 @@ public class QueryIntelligenceService {
             switch (queryType) {
                 case "SHOW_TABLES":
                     return handleShowTables(query);
+                case "ACCESSIBLE_TABLES":
+                    return handleAccessibleTables(query);
                 case "DESCRIBE_TABLE":
                     return handleDescribeTable(query);
                 case "SAMPLE_DATA":
@@ -110,6 +114,21 @@ public class QueryIntelligenceService {
         response.put("schemas", schemaTablesMap);
         response.put("message", "Available tables organized by schema");
         
+        return response;
+    }
+
+    /**
+     * Handle requests to list only tables with access permissions
+     */
+    private Map<String, Object> handleAccessibleTables(String query) throws SQLException {
+        Map<String, Object> response = new HashMap<>();
+
+        List<String> accessible = prestoService.getAccessibleTables();
+
+        response.put("type", "accessible_table_list");
+        response.put("tables", accessible);
+        response.put("message", "Tables accessible for querying");
+
         return response;
     }
     


### PR DESCRIPTION
## Summary
- add service method to verify table access and gather accessible tables
- expose new `accessible_tables` MCP tool and query handling
- document permission-aware table listing in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689622308d88832e9626f455bb559708