### PR TITLE
Handle unknown query type with error response

### DIFF
--- a/src/main/java/com/santec/polenta/service/QueryIntelligenceService.java
+++ b/src/main/java/com/santec/polenta/service/QueryIntelligenceService.java
@@ -50,6 +50,10 @@ public class QueryIntelligenceService {
                     return handleSampleData(query);
                 case "SEARCH_TABLES":
                     return handleSearchTables(query);
+                case "DIRECT_SQL":
+                    return handleDirectSQL(query);
+                case "UNKNOWN":
+                    return createErrorResponse("Could not determine query type. Please refine your request.");
                 default:
                     return handleDirectSQL(query);
             }


### PR DESCRIPTION
## Summary
- Distinguish between direct SQL and unknown queries in `QueryIntelligenceService`.
- Return a descriptive error when query type is unknown instead of executing it.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68965deb7618832ead1cce1516001936