### PR TITLE
Align Presto default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd polenta
 Editar `src/main/resources/application.yml`:
 ```yaml
 presto:
-  url: jdbc:presto://tu-servidor-presto:8080/hive/default
+  url: jdbc:presto://tu-servidor-presto:8082/hive/default
   user: tu-usuario
   password: tu-password
   catalog: hive

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 
 # PrestoDB Configuration
 presto:
-  url: ${PRESTO_URL:jdbc:presto://localhost:8081/hive/default}
+  url: ${PRESTO_URL:jdbc:presto://localhost:8082/hive/default}
   user: ${PRESTO_USER:admin}
   password: ${PRESTO_PASSWORD:}
   catalog: ${PRESTO_CATALOG:hive}


### PR DESCRIPTION
## Summary
- default Presto URL updated to port 8082
- README reflects Presto running on port 8082

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.santec:polenta-mcp-server: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68965def1ae4832ebc9aad5e9867ca1c