### PR TITLE
Apply Presto connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ presto:
   password: tu-password
   catalog: hive
   schema: default
+  connection-timeout: 5000 # Tiempo de espera para establecer la conexión (ms)
+  query-timeout: 10000     # Tiempo máximo para ejecutar consultas (ms)
 ```
 
 3. **Compilar y ejecutar**

--- a/src/main/java/com/santec/polenta/config/PrestoConfig.java
+++ b/src/main/java/com/santec/polenta/config/PrestoConfig.java
@@ -20,7 +20,7 @@ public class PrestoConfig {
     private String catalog;
     /** Default schema used for queries */
     private String schema;
-    /** Connection timeout in milliseconds */
+    /** Connection timeout in milliseconds applied to the JDBC login process */
     private long connectionTimeout;
     /** Query timeout in milliseconds */
     private long queryTimeout;

--- a/src/main/java/com/santec/polenta/service/PrestoService.java
+++ b/src/main/java/com/santec/polenta/service/PrestoService.java
@@ -117,9 +117,21 @@ public class PrestoService {
         if (prestoConfig.getQueryTimeout() > 0) {
             properties.setProperty("socketTimeout", String.valueOf(prestoConfig.getQueryTimeout()));
         }
-        Connection conn = DriverManager.getConnection(prestoConfig.getUrl(), properties);
-        logger.debug("Conexión establecida correctamente");
-        return conn;
+        int previousLoginTimeout = DriverManager.getLoginTimeout();
+        if (prestoConfig.getConnectionTimeout() > 0) {
+            properties.setProperty("connectionTimeout", String.valueOf(prestoConfig.getConnectionTimeout()));
+            int timeoutSeconds = (int) Math.ceil(prestoConfig.getConnectionTimeout() / 1000.0);
+            DriverManager.setLoginTimeout(timeoutSeconds);
+        }
+        try {
+            Connection conn = DriverManager.getConnection(prestoConfig.getUrl(), properties);
+            logger.debug("Conexión establecida correctamente");
+            return conn;
+        } finally {
+            if (prestoConfig.getConnectionTimeout() > 0) {
+                DriverManager.setLoginTimeout(previousLoginTimeout);
+            }
+        }
     }
 
     public boolean testConnection() {

--- a/src/test/java/com/santec/polenta/service/PrestoServiceTest.java
+++ b/src/test/java/com/santec/polenta/service/PrestoServiceTest.java
@@ -1,0 +1,42 @@
+package com.santec.polenta.service;
+
+import com.santec.polenta.config.PrestoConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PrestoServiceTest {
+
+    @Test
+    void appliesConnectionTimeout() throws Exception {
+        PrestoConfig config = new PrestoConfig();
+        config.setUrl("jdbc:presto://localhost:9/hive/default");
+        config.setUser("test");
+        config.setConnectionTimeout(1234);
+
+        PrestoService service = new PrestoService();
+        ReflectionTestUtils.setField(service, "prestoConfig", config);
+
+        int originalTimeout = DriverManager.getLoginTimeout();
+        int expectedTimeoutSeconds = (int) Math.ceil(config.getConnectionTimeout() / 1000.0);
+
+        Method method = PrestoService.class.getDeclaredMethod("getConnection");
+        method.setAccessible(true);
+        try {
+            method.invoke(service);
+            fail("Expected SQLException");
+        } catch (InvocationTargetException ex) {
+            assertTrue(ex.getCause() instanceof SQLException);
+        }
+
+        assertEquals(expectedTimeoutSeconds, DriverManager.getLoginTimeout());
+
+        DriverManager.setLoginTimeout(originalTimeout);
+    }
+}


### PR DESCRIPTION
## Summary
- apply `connectionTimeout` to Presto JDBC connections and reset login timeout after use
- document connection timeout property
- add unit test verifying login timeout propagation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68965de7c874832eb1328b92039f361e