### PR TITLE
Add configurable Presto query timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ mcp:
     enabled: true  # Habilitar endpoints helper (desactivar en producción)
 ```
 
+El parámetro `presto.query-timeout` define el tiempo máximo permitido para la ejecución de consultas (en milisegundos).
+
 3. **Compilar y ejecutar**
  ```bash
  mvn clean install

--- a/src/main/java/com/santec/polenta/service/PrestoService.java
+++ b/src/main/java/com/santec/polenta/service/PrestoService.java
@@ -28,6 +28,8 @@ public class PrestoService {
         try (Connection connection = getConnection();
              PreparedStatement statement = connection.prepareStatement(sql)) {
 
+            statement.setQueryTimeout((int) prestoConfig.getQueryTimeout());
+
             for (int i = 0; i < params.length; i++) {
                 statement.setObject(i + 1, params[i]);
             }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,13 +9,13 @@ spring:
 
 # PrestoDB Configuration
 presto:
-  url: ${PRESTO_URL:jdbc:presto://localhost:8081/tpch/sf1}
-  user: ${PRESTO_USER:admin}
-  password: ${PRESTO_PASSWORD:}
+    url: ${PRESTO_URL:jdbc:presto://localhost:8081/tpch/sf1}
+    user: ${PRESTO_USER:admin}
+    password: ${PRESTO_PASSWORD:}
 
-  catalog: ${PRESTO_CATALOG:tpch}
-  schema: ${PRESTO_SCHEMA:sf1}
-  query-timeout: 30000
+    catalog: ${PRESTO_CATALOG:tpch}
+    schema: ${PRESTO_SCHEMA:sf1}
+    query-timeout: 30000 # Tiempo máximo para ejecutar consultas (ms)
 
 
 


### PR DESCRIPTION
## Summary
- Set `PreparedStatement` query timeout using `presto.query-timeout` configuration
- Document `presto.query-timeout` in README and sample `application.yml`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68990511a5d0832eb13c32ce8e1907c0